### PR TITLE
Polish installation guide visuals with cards and color accents

### DIFF
--- a/install.html
+++ b/install.html
@@ -1,0 +1,225 @@
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>プラグイン導入ガイド | Puchi Add-on Plugins</title>
+  <meta name="description" content="kintone ミニプラグインのインストールからアップデートまでの共通手順をまとめたガイドです。">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="kb-root">
+  <div class="kb-container kb-topbar">
+    <a class="kb-back" href="index.html">← 商品一覧に戻る</a>
+    <div class="kb-brand">Puchi Add-on Plugins</div>
+  </div>
+
+  <main class="kb-container">
+    <article class="kb-article">
+      <header class="kb-article-header">
+        <p class="kb-article-label">kintone ミニプラグイン導入ガイド</p>
+        <h1>インストール〜アップデートまでの共通手順</h1>
+        <div class="kb-article-meta">
+          <div class="kb-meta-chip">
+            <strong>最終更新</strong>
+            <span>2025年9月</span>
+          </div>
+          <div class="kb-meta-chip">
+            <strong>対象</strong>
+            <span>kintone システム管理者・アプリ管理者</span>
+          </div>
+          <div class="kb-meta-chip">
+            <strong>サポート窓口</strong>
+            <span>ご購入時にご案内したメールアドレスまで</span>
+          </div>
+        </div>
+      </header>
+
+      <div class="kb-article-body">
+        <section class="kb-article-section">
+          <h2>配布ファイル構成</h2>
+          <div class="kb-section-card">
+            <ul class="kb-article-list">
+              <li><strong>プラグイン本体（ZIP）</strong>：kintone へそのままアップロードしてください。</li>
+              <li><strong>導入ガイド（PDF）</strong>：本ドキュメント。社内共有にもご利用ください。</li>
+            </ul>
+          </div>
+        </section>
+
+        <section class="kb-article-section">
+          <h2>想定読者</h2>
+          <div class="kb-section-card">
+            <p class="kb-article-paragraph">kintone の管理機能にアクセスできる担当者。IT 操作に不慣れな方でも手順を追えるよう記載しています。</p>
+          </div>
+        </section>
+
+        <section class="kb-article-section">
+          <h2>お問い合わせ前に</h2>
+          <div class="kb-section-card">
+            <p class="kb-article-paragraph">プラグイン名・バージョン、発生現象が分かるスクリーンショットをご用意いただくと解決がスムーズです。</p>
+          </div>
+        </section>
+
+        <nav class="kb-article-toc" aria-label="目次">
+          <h2>Contents</h2>
+          <ol class="kb-article-ordered">
+            <li><a href="#checklist">導入前のチェックリスト</a></li>
+            <li><a href="#package">プラグイン配布物の確認</a></li>
+            <li><a href="#install">kintone へのプラグイン追加手順</a></li>
+            <li><a href="#app-enable">アプリでの設定と有効化</a></li>
+            <li><a href="#update">プラグインのアップデート方法</a></li>
+            <li><a href="#troubleshoot">トラブルシュート</a></li>
+            <li><a href="#support">サポート窓口と連絡先</a></li>
+          </ol>
+        </nav>
+
+        <section id="checklist" class="kb-article-section">
+          <h2>1. 導入前のチェックリスト</h2>
+          <div class="kb-section-card kb-section-card--stack">
+            <ul class="kb-article-check">
+              <li>kintone の「システム管理」メニューにアクセスできる権限をお持ちですか？</li>
+              <li>利用する環境（本番 or テスト）でプラグインの動作検証を行うスペース／アプリを用意しましたか？</li>
+              <li>ご利用のブラウザーは最新版ですか？（Google Chrome を推奨）</li>
+              <li>既存のプラグインと併用する場合、念のためテストアプリで競合が無いか確認することをおすすめします。</li>
+            </ul>
+            <p class="kb-article-callout"><strong>ご注意：</strong>プラグインの追加や更新は、アプリに影響が出る可能性があります。本番アプリに適用する前にテストアプリで検証してください。</p>
+          </div>
+        </section>
+
+        <section id="package" class="kb-article-section">
+          <h2>2. プラグイン配布物の確認</h2>
+          <div class="kb-section-card kb-section-card--stack">
+            <p class="kb-article-paragraph">ダウンロードした ZIP の中身を確認し、少なくとも以下のファイルが揃っていることを確かめてください。</p>
+            <ul class="kb-article-list">
+              <li><strong>プラグイン本体（ZIP）</strong>：kintone にアップロードするファイルです。解凍せず、そのまま使用します。</li>
+              <li><strong>導入ガイド PDF</strong>：操作手順書。本ドキュメントが該当します。</li>
+            </ul>
+            <p class="kb-article-hint">ヒント：Windows で ZIP を右クリックし「すべて展開」を選ぶとフォルダーが開きます。Mac の場合はダブルクリックで展開されます。</p>
+          </div>
+        </section>
+
+        <section id="install" class="kb-article-section">
+          <h2>3. kintone へのプラグイン追加手順</h2>
+          <div class="kb-section-card">
+            <ol class="kb-article-steps">
+              <li>
+                <h3>kintone のシステム管理を開きます</h3>
+                <p>画面右上のアカウントメニューから 「システム管理」（または「管理者設定」）を選択します。</p>
+                <p class="kb-screenshot-callout">★ スクリーンショット「システム管理メニュー」の挿入位置</p>
+              </li>
+              <li>
+                <h3>プラグイン管理画面へ移動</h3>
+                <p>左側のメニューから 「カスタマイズ／サービス連携」&gt;「プラグイン」 を開き、右上の 「プラグインの追加」&gt;「ファイルから」 をクリックします。</p>
+              </li>
+              <li>
+                <h3>プラグインファイルを選択</h3>
+                <p>配布されたプラグイン本体（ZIP）を選択し、「追加」をクリックします。アップロード完了後、一覧に表示されます。</p>
+                <p class="kb-screenshot-callout">★ スクリーンショット「プラグイン一覧に表示」の挿入位置</p>
+              </li>
+              <li>
+                <h3>有効化の準備</h3>
+                <p>追加できたら、該当プラグインのステータスが「利用可能」になっていることを確認してください。アプリへの適用は次の章で行います。</p>
+              </li>
+            </ol>
+          </div>
+        </section>
+
+        <section id="app-enable" class="kb-article-section">
+          <h2>4. アプリでの設定と有効化</h2>
+          <div class="kb-section-card">
+            <ol class="kb-article-steps">
+              <li>
+                <h3>プラグインを使うアプリを開く</h3>
+                <p>アプリの設定（歯車アイコン）&gt; 「プラグイン」 を選択し、「+ プラグインを追加」 をクリックします。</p>
+              </li>
+              <li>
+                <h3>プラグインの設定画面に入る</h3>
+                <p>一覧から対象プラグインを選択し、「設定」ボタンをクリック。画面の案内に沿って必要項目を入力し、保存します。</p>
+                <p class="kb-screenshot-callout">★ スクリーンショット「設定画面」の挿入位置</p>
+              </li>
+              <li>
+                <h3>アプリを更新（再利用）</h3>
+                <p>設定を保存したら、アプリ設定画面右上の 「保存」、続いて黄色の 「アプリを更新」 ボタンを押してください。これでプラグインが有効になります。</p>
+              </li>
+              <li>
+                <h3>動作確認</h3>
+                <p>アプリ画面に戻り、想定どおりに動作するか確認します。問題がある場合は設定値や他プラグインとの競合をチェックしてください。</p>
+              </li>
+            </ol>
+          </div>
+        </section>
+
+        <section id="update" class="kb-article-section">
+          <h2>5. プラグインのアップデート方法</h2>
+          <div class="kb-section-card">
+            <ol class="kb-article-steps">
+              <li>配布サイトから最新版のプラグイン本体（ZIP）とガイドをダウンロードします。</li>
+              <li>kintone システム管理 &gt; プラグイン一覧で対象プラグインの 「…（メニュー）」&gt;「更新」 を選択します。</li>
+              <li>新しい ZIP を指定し、アップロード後にアプリ設定画面で 「アプリを更新」 を忘れずに実行します。</li>
+              <li>必要に応じて、リリースノートや変更点をアプリ利用者へ共有してください。</li>
+              <li>旧バージョンの ZIP はバックアップとして保管しておくと、万一のロールバック時に安心です。</li>
+            </ol>
+          </div>
+        </section>
+
+        <section id="troubleshoot" class="kb-article-section">
+          <h2>6. トラブルシュート</h2>
+          <div class="kb-section-card kb-section-card--stack">
+            <div>
+              <h3 class="kb-article-subheading">画面が真っ白になる／プラグインが動かない場合</h3>
+              <ul class="kb-article-check">
+                <li>ブラウザーの再読み込み（Ctrl + F5 または Cmd + Shift + R）を実行してください。</li>
+                <li>他プラグインを一時的に無効化し、競合が無いか切り分けます。</li>
+                <li>プラグイン設定内容が正しいか、入力漏れが無いか確認します。</li>
+              </ul>
+            </div>
+            <div>
+              <h3 class="kb-article-subheading">アップデート後にエラーが出る場合</h3>
+              <ul class="kb-article-check">
+                <li>アプリを更新し忘れていないか確認してください。</li>
+                <li>アプリのカスタマイズ JavaScript / CSS との競合も考えられるため、一時的に無効化して様子を見ます。</li>
+                <li>エラーメッセージが表示される場合は、スクリーンショットを撮影してサポート窓口へお知らせください。</li>
+              </ul>
+            </div>
+          </div>
+        </section>
+
+        <div class="kb-divider" role="presentation"></div>
+
+        <section id="support" class="kb-article-section">
+          <h2>7. サポート窓口と連絡先</h2>
+          <div class="kb-section-card">
+            <p class="kb-article-paragraph">解決しない場合は、以下の情報を添えてサポート窓口までご連絡ください。</p>
+            <div class="kb-support-cards">
+              <div class="kb-support-card">
+                <strong>お問い合わせ時のチェック項目</strong>
+                <ul>
+                  <li>ご利用中のプラグイン名とバージョン</li>
+                  <li>発生日時・操作手順</li>
+                  <li>表示されたエラーメッセージやスクリーンショット</li>
+                  <li>kintone のドメイン名（例：example.cybozu.com）</li>
+                </ul>
+              </div>
+              <div class="kb-support-card">
+                <strong>サポート窓口</strong>
+                <p class="kb-article-paragraph">ご購入時にご案内したメールアドレス / フォームまでご連絡ください。</p>
+                <p class="kb-support-meta">受付時間：平日 10:00 – 18:00（日本時間）<br>※祝日・弊社指定休日を除く</p>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <p class="kb-article-footer">© 2025 Mini Plugin Team. All rights reserved. 無断転載を禁じます。</p>
+      </div>
+    </article>
+  </main>
+
+  <footer class="kb-footer kb-container">
+    <nav class="kb-footer-links">
+      <a href="mailto:c.otkyaaa@gmail.com">不具合報告</a>
+      <a href="install.html">プラグイン導入ガイド</a>
+      <a href="terms.html">利用規約</a>
+    </nav>
+    <small>© 2025 Mini Plugin Team. All rights reserved.</small>
+  </footer>
+</body>
+</html>

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -184,7 +184,7 @@ try{
   // assets は丸ごと
   copy('assets');
   // 単体ファイル
-  ['style.css','terms.html','robots.txt','sitemap-base.xml','404.html'].forEach(copy);
+  ['style.css','terms.html','install.html','robots.txt','sitemap-base.xml','404.html'].forEach(copy);
 
   // sitemap
   const basePath=path.join(DIST,'sitemap-base.xml');
@@ -192,6 +192,7 @@ try{
   const urls=['/index.html'];
   if(ENABLE_EN) urls.push('/en/index.html');
   urls.push('/terms.html');
+  urls.push('/install.html');
   for(const p of products){
     urls.push(`/products/${p.slug}.html`);
     if(ENABLE_EN) urls.push(`/products/en/${p.slug}.html`);

--- a/style.css
+++ b/style.css
@@ -11,6 +11,8 @@
   --kb-sub:#6b7280;
   --kb-line:#e6eef7;
   --kb-primary:#2f64e2;
+  --kb-primary-100:#eaf0ff;
+  --kb-primary-200:#d8e4ff;
   --kb-primary-600:#2b57c7;
   --kb-primary-700:#224bb1;
   --kb-ink:#0b1f33;
@@ -19,8 +21,15 @@
   --kb-gap-lg:16px;
 }
 .kb-root[data-kb-theme="soft-dark"]{
-  --kb-bg:#2c2f33; --kb-surface:#30343a; --kb-text:#f5f6fa; --kb-sub:#c5c7ce;
-  --kb-line:#3c4047; --kb-primary:#7289da; --kb-primary-600:#667bd0; --kb-primary-700:#4f63a8; --kb-ink:#0f1115;
+  --kb-bg:#2c2f33;
+  --kb-surface:#30343a;
+  --kb-text:#f5f6fa;
+  --kb-sub:#c5c7ce;
+  --kb-line:#3c4047;
+  --kb-primary:#7289da;
+  --kb-primary-600:#667bd0;
+  --kb-primary-700:#4f63a8;
+  --kb-ink:#0f1115;
 }
 
 /* ===== RESET & BASE ===== */
@@ -32,6 +41,55 @@
 .kb-root a{color:var(--kb-primary);text-decoration:none}
 .kb-root a:hover{text-decoration:underline}
 .kb-root a:focus-visible{outline:2px solid var(--kb-primary-600);outline-offset:2px}
+.kb-article{background:#fff;border:1px solid var(--kb-line);border-radius:24px;padding:0 0 56px;box-shadow:0 22px 48px rgba(15,23,42,.09);max-width:940px;margin:0 auto 96px;overflow:hidden}
+.kb-article-header{padding:48px 56px 40px;background:linear-gradient(150deg,#f6f9ff 0%,#fff 42%,#eef3ff 100%)}
+.kb-article-header h1{font-size:30px;font-weight:800;line-height:1.35;margin:6px 0 0}
+.kb-article-label{display:inline-block;font-size:13px;font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:var(--kb-primary);background:#ecf2ff;border-radius:999px;padding:6px 18px;box-shadow:0 4px 12px rgba(47,100,226,.18)}
+.kb-article-meta{margin-top:24px;display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:14px;font-size:14px}
+.kb-meta-chip{background:#fff;border-radius:16px;padding:12px 16px;border:1px solid rgba(47,100,226,.14);display:flex;gap:8px;align-items:flex-start;color:var(--kb-sub);line-height:1.7;box-shadow:0 12px 28px rgba(15,23,42,.05)}
+.kb-meta-chip strong{color:var(--kb-text)}
+.kb-article-body{padding:0 56px}
+.kb-article-section{margin-top:40px}
+.kb-article-section:first-of-type{margin-top:32px}
+.kb-article-section h2{font-size:22px;font-weight:800;margin:0;color:var(--kb-text)}
+.kb-article-paragraph{margin-top:12px;color:var(--kb-sub);line-height:1.8}
+.kb-section-card{margin-top:18px;background:linear-gradient(140deg,#fff,#f8fbff);border:1px solid rgba(116,140,180,.18);border-radius:20px;padding:24px 28px;box-shadow:0 20px 44px rgba(15,23,42,.06)}
+.kb-section-card--stack{display:grid;gap:18px}
+.kb-article-list,.kb-article-check{list-style:none;margin:0;display:grid;gap:12px;color:var(--kb-text)}
+.kb-article-list li,.kb-article-check li{position:relative;padding:14px 18px 14px 42px;border-radius:16px;background:#fff;border:1px solid rgba(45,60,86,.08);box-shadow:0 4px 10px rgba(15,23,42,.04)}
+.kb-article-list li::before{content:"📄";position:absolute;left:16px;top:14px;font-size:16px}
+.kb-article-check li::before{content:"✔";position:absolute;left:16px;top:14px;font-size:16px;color:#15803d;font-weight:700}
+.kb-article-ordered{list-style:decimal;padding-left:1.6em;margin:12px 0 0;display:grid;gap:6px;font-weight:600}
+.kb-article-ordered a{color:var(--kb-primary)}
+.kb-article-toc{margin:48px 0;background:linear-gradient(160deg,#26457b 0%,#3d6ee8 100%);border-radius:20px;padding:28px 32px;box-shadow:0 18px 36px rgba(35,70,140,.28);color:#f8fbff}
+.kb-article-toc h2{margin:0 0 12px;font-size:18px;font-weight:700;color:#f8fbff}
+.kb-article-toc a{color:#dbe7ff;font-weight:600}
+.kb-article-toc a:hover{color:#fff}
+.kb-article-steps{list-style:none;margin:0;display:grid;gap:18px;color:var(--kb-text);counter-reset:step}
+.kb-article-steps li{position:relative;padding:22px 22px 22px 68px;border-radius:20px;background:#fff;border:1px solid rgba(45,60,86,.12);box-shadow:0 18px 32px rgba(15,23,42,.06)}
+.kb-article-steps li::before{content:counter(step,decimal-leading-zero);counter-increment:step;background:var(--kb-primary);color:#fff;font-weight:700;border-radius:14px;padding:12px 16px;font-size:16px;position:absolute;left:22px;top:22px;min-width:36px;text-align:center;box-shadow:0 10px 22px rgba(47,100,226,.35)}
+.kb-article-steps h3{font-size:17px;font-weight:700;margin:0 0 8px;color:var(--kb-text)}
+.kb-article-steps p{margin:0 0 6px;color:var(--kb-sub);line-height:1.7}
+.kb-article-callout{margin-top:20px;padding:18px 22px;border-radius:16px;background:#fff7eb;border-left:5px solid #f59e0b;font-size:14px;color:#8a5300;box-shadow:0 12px 28px rgba(245,158,11,.18)}
+.kb-article-hint{margin-top:20px;padding:16px 22px;border-radius:16px;background:#eef5ff;border-left:5px solid #3b82f6;color:#2c4a7a;font-size:14px;box-shadow:0 12px 28px rgba(59,130,246,.18)}
+.kb-screenshot-callout{margin-top:12px;padding:12px 16px;border-radius:12px;border:1px dashed var(--kb-line);background:#f9fbff;font-size:13px;color:#4b5563}
+.kb-article-subheading{margin:28px 0 10px;font-size:18px;font-weight:700;color:var(--kb-text)}
+.kb-article-footer{margin-top:56px;font-size:12.5px;color:var(--kb-sub);text-align:center}
+.kb-support-cards{display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:18px;margin-top:18px}
+.kb-support-card{background:#fff;border-radius:18px;padding:18px 20px;border:1px solid rgba(47,100,226,.14);box-shadow:0 14px 30px rgba(15,23,42,.05);display:grid;gap:10px}
+.kb-support-card strong{font-size:15px;color:var(--kb-text)}
+.kb-support-card ul{margin:0;list-style:none;padding:0;display:grid;gap:6px;color:var(--kb-sub)}
+.kb-support-card ul li::before{content:"• ";color:var(--kb-primary);font-weight:700}
+.kb-support-meta{font-size:13px;color:var(--kb-sub)}
+.kb-divider{margin:48px auto 0;height:1px;width:100%;max-width:520px;background:linear-gradient(90deg,rgba(47,100,226,0),rgba(47,100,226,.35),rgba(47,100,226,0))}
+@media (max-width:720px){
+  .kb-article{margin-bottom:56px}
+  .kb-article-header{padding:36px 28px}
+  .kb-article-header h1{font-size:26px}
+  .kb-article-body{padding:0 24px}
+  .kb-meta-chip{flex-direction:column;gap:4px}
+  .kb-article-toc{margin:36px 0;padding:24px}
+}
 
 /* ===== LAYOUT ===== */
 .kb-container{max-width:1080px;margin:0 auto;padding:24px}

--- a/templates/index-ja.html
+++ b/templates/index-ja.html
@@ -44,6 +44,7 @@
   <footer class="kb-footer kb-container">
     <nav class="kb-footer-links">
       <a href="mailto:%%SUPPORT_MAIL%%">不具合報告</a>
+      <a href="install.html">プラグイン導入ガイド</a>
       <a href="terms.html">利用規約</a>
     </nav>
     <small>%%SITE_COPYRIGHT%%</small>

--- a/templates/product-ja.html
+++ b/templates/product-ja.html
@@ -79,6 +79,7 @@
   <footer class="kb-footer kb-container">
     <nav class="kb-footer-links">
       <a href="mailto:%%SUPPORT_MAIL%%">不具合報告</a>
+      <a href="../install.html">プラグイン導入ガイド</a>
       <a href="../terms.html">利用規約</a>
     </nav>
     <small>%%SITE_COPYRIGHT%%</small>


### PR DESCRIPTION
## Summary
- redesign the installation guide layout with hero meta chips, section cards, and richer callouts for readability
- refresh article typography and component styles to support the new card-based presentation and support contact tiles

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9df1fc4b48324895301118d7abbf0