### PR TITLE
Adjust knowledge base step badge spacing

### DIFF
--- a/style.css
+++ b/style.css
@@ -68,8 +68,8 @@
 .kb-article-toc a{color:#3758a0;font-weight:600}
 .kb-article-toc a:hover{color:#223b7d}
 .kb-article-steps{list-style:none;margin:0;display:grid;gap:18px;color:var(--kb-text);counter-reset:step}
-.kb-article-steps li{position:relative;padding:24px 26px 24px 88px;border-radius:22px;background:#fff;border:1px solid rgba(45,60,86,.08);box-shadow:0 16px 30px rgba(15,23,42,.05)}
-.kb-article-steps li::before{content:counter(step,decimal-leading-zero);counter-increment:step;background:var(--kb-primary-050);color:#27428f;font-weight:700;border-radius:16px;padding:12px 16px;font-size:16px;position:absolute;left:28px;top:28px;min-width:44px;text-align:center;box-shadow:0 8px 18px rgba(47,100,226,.18);border:1px solid rgba(47,100,226,.18)}
+.kb-article-steps li{position:relative;padding:24px 26px 24px 132px;border-radius:22px;background:#fff;border:1px solid rgba(45,60,86,.08);box-shadow:0 16px 30px rgba(15,23,42,.05)}
+.kb-article-steps li::before{content:counter(step,decimal-leading-zero);counter-increment:step;background:var(--kb-primary-100);color:#27428f;font-weight:700;border-radius:16px;display:flex;align-items:center;justify-content:center;width:60px;height:60px;font-size:16px;position:absolute;left:36px;top:24px;box-shadow:0 8px 18px rgba(47,100,226,.14);border:1px solid var(--kb-primary-200)}
 .kb-article-steps h3{font-size:17px;font-weight:700;margin:0 0 8px;color:var(--kb-text)}
 .kb-article-steps p{margin:0 0 6px;color:var(--kb-sub);line-height:1.7}
 .kb-article-callout{margin-top:20px;padding:20px 24px;border-radius:18px;background:#fff9ed;border:1px solid rgba(245,158,11,.26);font-size:14px;color:#8a5a06;box-shadow:0 12px 26px rgba(245,158,11,.14)}
@@ -92,6 +92,8 @@
   .kb-article-body{padding:0 24px}
   .kb-meta-chip{flex-direction:column;gap:4px}
   .kb-article-toc{margin:36px 0;padding:24px}
+  .kb-article-steps li{padding:24px 20px 24px 96px}
+  .kb-article-steps li::before{width:48px;height:48px;left:28px;top:24px;font-size:15px;border-radius:14px}
 }
 
 /* ===== LAYOUT ===== */


### PR DESCRIPTION
## Summary
- increase the horizontal padding on knowledge base step items so text clears the numbered badge
- restyle the badge with a centered square treatment and softer pastel colors
- add a mobile breakpoint to shrink the badge and padding for small screens

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9e70a61fc832486563529919dbde8